### PR TITLE
Added compatibility for PHP 7.2.x

### DIFF
--- a/src/HasTemporaryFields.php
+++ b/src/HasTemporaryFields.php
@@ -8,6 +8,8 @@ trait HasTemporaryFields
 {
     protected static function fillFields(NovaRequest $request, $model, $fields)
     {
-        return parent::fillFields($request, $model, $fields->reject(fn ($field) => $field->meta['_temp'] ?? false));
+        return parent::fillFields($request, $model, $fields->reject(function ($field) {
+            return $field->meta['_temp'] ?? false;
+        }));
     }
 }


### PR DESCRIPTION
Added compatibility for PHP 7.2.x, as stated in the `composer.json`. Arrow Functions are [available for PHP ^7.4](https://www.php.net/manual/en/functions.arrow.php)